### PR TITLE
Fix cleaning error in countDevicesByLocation

### DIFF
--- a/src/cli/commands/pushMarketing.ts
+++ b/src/cli/commands/pushMarketing.ts
@@ -125,9 +125,22 @@ export class PushMarketing extends Command<ServerContext> {
       })) {
         const { apiKey, deviceToken, ignoreMarketing } = couchDevice.doc
 
-        if (ignoreMarketing || apiKey == null || deviceToken == null) {
+        // Skip document conditions:
+        if (
+          ignoreMarketing ||
+          apiKey == null ||
+          deviceToken == null ||
+          deviceToken.trim() === ''
+        ) {
           status.skipCount++
           updateStatusLine()
+          continue
+        }
+        if (!/^[a-zA-z0-9_\-:]+$/.test(deviceToken)) {
+          // Log invalid tokens
+          logger.write(
+            `Invalid token '${deviceToken}' for doc '${couchDevice.id}'`
+          )
           continue
         }
 

--- a/src/db/couchDevices.ts
+++ b/src/db/couchDevices.ts
@@ -176,9 +176,9 @@ export const countDevicesByLocation = async (
   })
 
   return results.rows.map(row => {
-    const key: string[] = asArray(asString)(row.key)
+    const key = asOptional(asArray(asString), [])(row.key)
     const count: number = asNumber(row.value)
-    return { key, count }
+    return { key: key, count }
   })
 }
 


### PR DESCRIPTION
Nano returns a null `key` field in the rows for the result set when there is no query location query parameters. This case must be handled and cleaned to an empty array.

### CHANGELOG

- Fix cleaning error in countDevicesByLocation

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204084794661574