### PR TITLE
Fix intermittent 500 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Do not return 500 errors when CouchDB views are out-of-date.
+
 ## 2.3.2 (2024-09-14)
 
 - fixed: Broken notifications due to deprecated Firebase API.

--- a/src/db/couchPushEvents.ts
+++ b/src/db/couchPushEvents.ts
@@ -221,9 +221,9 @@ export async function getEventsByDeviceId(
     include_docs: true,
     key: deviceId
   })
-  return response.rows.map(row =>
-    makePushEventRow(db, asCouchPushEvent(row.doc))
-  )
+  return response.rows
+    .filter(row => row.doc != null)
+    .map(row => makePushEventRow(db, asCouchPushEvent(row.doc)))
 }
 
 export async function getEventsByLoginId(
@@ -235,9 +235,9 @@ export async function getEventsByLoginId(
     include_docs: true,
     key: base64.stringify(loginId)
   })
-  return response.rows.map(row =>
-    makePushEventRow(db, asCouchPushEvent(row.doc))
-  )
+  return response.rows
+    .filter(row => row.doc != null)
+    .map(row => makePushEventRow(db, asCouchPushEvent(row.doc)))
 }
 
 export async function* streamEvents(


### PR DESCRIPTION
When executing a view with `include_docs` set to `true`, there are still cases where CouchDB will randomly return `null` for the document. Work around these cases by filtering out null documents before cleaning.

Since CouchDB has eventual consistency, we expect glitches like this from time to time. Presumably this error happens when the view is out-of-date relative to the documents themselves.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206812370550010