### PR TITLE
Move API keys to their own settings document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Move API keys to a separate settings document.
+
 ## 2.4.1 (2024-12-23)
 
 - fixed: Do not exit the price-change daemon when a rate is missing

--- a/src/db/couchSettings.ts
+++ b/src/db/couchSettings.ts
@@ -1,5 +1,4 @@
 import {
-  asArray,
   asBoolean,
   asEither,
   asMaybe,
@@ -18,23 +17,18 @@ import {
  * Live-updating server options stored in the `push-settings` database.
  */
 const asSettings = asObject({
-  apiKeys: asMaybe(
-    asArray(
-      asObject({
-        name: asString,
-        apiKey: asString
-      })
-    ),
-    []
-  ),
-  ratesServer: asMaybe(asString, 'https://rates2.edge.app'),
-
   // Mode toggles:
   debugLogs: asMaybe(asBoolean, false),
-  daemonMaxHours: asMaybe(asNumber, 1),
+  daemonMaxHours: asMaybe(asNumber, 1)
+})
 
-  // Other services we rely on:
+/**
+ * Keys to outside services we rely on.
+ */
+const asServices = asObject({
   infuraProjectId: asMaybe(asString, ''),
+  ipApiKey: asMaybe(asString, ''),
+  ratesServer: asMaybe(asString, 'https://rates2.edge.app'),
   slackUri: asMaybe(asEither(asString, asNull), null)
 })
 
@@ -44,8 +38,9 @@ export const syncedReplicators = syncedDocument(
 )
 
 export const syncedSettings = syncedDocument('settings', asSettings.withRest)
+export const syncedServices = syncedDocument('services', asServices.withRest)
 
 export const settingsSetup: DatabaseSetup = {
   name: 'push-settings',
-  syncedDocuments: [syncedReplicators, syncedSettings]
+  syncedDocuments: [syncedReplicators, syncedServices, syncedSettings]
 }

--- a/src/miniPlugins/miniPlugins.ts
+++ b/src/miniPlugins/miniPlugins.ts
@@ -1,4 +1,4 @@
-import { syncedSettings } from '../db/couchSettings'
+import { syncedServices } from '../db/couchSettings'
 import { MiniPlugins } from '../types/miniPlugin'
 import { makeBlockbookPlugin } from './blockbook'
 import { makeEvmPlugin } from './evm'
@@ -107,10 +107,10 @@ export function makePlugins(): MiniPlugins {
     // wax: makeEvmPlugin('https://wax.greymass.com'), // not sure
     // polkadot: makeEvmPlugin('wss://rpc.polkadot.io'), // not sure
     ethereum: makeEvmPlugin(
-      `https://mainnet.infura.io/v3/${syncedSettings.doc.infuraProjectId}`
+      `https://mainnet.infura.io/v3/${syncedServices.doc.infuraProjectId}`
     ),
     kovan: makeEvmPlugin(
-      `https://kovan.infura.io/v3/${syncedSettings.doc.infuraProjectId}`
+      `https://kovan.infura.io/v3/${syncedServices.doc.infuraProjectId}`
     ),
     ethereumclassic: makeEvmPlugin('https://www.ethercluster.com/etc'),
     fantom: makeEvmPlugin('https://rpc.ftm.tools'),

--- a/src/util/ratesCache.ts
+++ b/src/util/ratesCache.ts
@@ -1,7 +1,7 @@
 import { asEither, asNull, asObject, asString } from 'cleaners'
 import fetch from 'node-fetch'
 
-import { syncedSettings } from '../db/couchSettings'
+import { syncedServices } from '../db/couchSettings'
 
 export interface RatesCache {
   getRate: (currencyPair: string, date: Date) => Promise<number | null>
@@ -50,7 +50,7 @@ async function getFromServer(
   currencyPair: string,
   date: Date
 ): Promise<number | null> {
-  const { ratesServer } = syncedSettings.doc
+  const { ratesServer } = syncedServices.doc
   const response = await fetch(
     `${ratesServer}/v2/exchangeRate?currency_pair=${currencyPair}&date=${date.toISOString()}`
   )

--- a/src/util/services/ip-api.ts
+++ b/src/util/services/ip-api.ts
@@ -1,7 +1,7 @@
 import { asEither, asObject, asString, asValue } from 'cleaners'
 import fetch from 'node-fetch'
 
-import { syncedSettings } from '../../db/couchSettings'
+import { syncedServices } from '../../db/couchSettings'
 import { Device } from '../../types/pushTypes'
 
 const asApiReply = asEither(
@@ -20,14 +20,10 @@ const asApiReply = asEither(
 )
 
 export async function locateIp(ip: string): Promise<Device['location']> {
-  const { apiKeys } = syncedSettings.doc
-  const { apiKey } = apiKeys.find(apiKey => apiKey.name === 'ipService') ?? {}
-
-  if (apiKey == null)
-    throw new Error(`Missing 'ipService' API Key in settings document`)
+  const { ipApiKey } = syncedServices.doc
 
   const reply = await fetch(
-    `https://pro.ip-api.com/json/${ip}?fields=49183&key=${apiKey}`
+    `https://pro.ip-api.com/json/${ip}?fields=49183&key=${ipApiKey}`
   )
   if (!reply.ok) {
     throw new Error(`IP lookup returned status code ${reply.status}`)

--- a/src/util/slackAlert.ts
+++ b/src/util/slackAlert.ts
@@ -1,10 +1,10 @@
 import fetch from 'node-fetch'
 
-import { syncedSettings } from '../db/couchSettings'
+import { syncedServices } from '../db/couchSettings'
 import { logger } from './logger'
 
 export function slackAlert(text: string): void {
-  const { slackUri } = syncedSettings.doc
+  const { slackUri } = syncedServices.doc
 
   if (slackUri == null) return
 


### PR DESCRIPTION
Similar to the login server, we want to put keys & URL's to external services into a separate document. That way, if something goes wrong when editing settings, we don't lose access to outside services.

Also flatten away the `apiKeys` array, which appears to be unused.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209027036942689