### PR TITLE
Prevent the publisher from getting clogged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - changed: Move API keys to a separate settings document.
 - fixed: Close the AMQP client when the CLI exits. This keeps the CLI from hanging.
+- fixed: Limit the number of in-flight messages to prevent the publisher from crashing.
 
 ## 2.4.1 (2024-12-23)
 

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -33,6 +33,9 @@ export async function makeConnections(): Promise<DbConnections> {
   const connection = await amqp.connect()
   const channel = await connection.channel()
 
+  // Limits the number of in-flight messages:
+  await channel.prefetch(50)
+
   return {
     couch: nano(serverConfig.couchUri),
     amqpClient: amqp,


### PR DESCRIPTION
We need to limit the number of in-flight messages, or the publisher will run out of memory and die.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210199425260804