### PR TITLE
Add a marketing tool API with marketer keys and audience queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- added: Marketing tool API endpoints: `POST /marketing/test` sends a single test push, `POST /marketing/query` lists the devices a send would reach (filtered by include/exclude lists of cities and regions), and `POST /marketing/push` sends to the device list a query returned.
+- added: A `marketer` flag and a `targetApiKeys` list on API keys. The marketing endpoints require the flag (or `admin`) and only reach devices registered under the listed keys, so the api keys baked into the apps cannot call them.
+
 ## 2.5.0 (2025-05-08)
 
 - changed: Move API keys to a separate settings document.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - added: Marketing tool API endpoints: `POST /marketing/test` sends a single test push, `POST /marketing/query` lists the devices a send would reach (filtered by include/exclude lists of cities and regions), and `POST /marketing/push` sends to the device list a query returned.
 - added: A `marketer` flag and a `targetApiKeys` list on API keys. The marketing endpoints require the flag (or `admin`) and only reach devices registered under the listed keys, so the api keys baked into the apps cannot call them.
+- fixed: Recognize Firebase's current "token not registered" error, so devices whose app has been uninstalled get their tokens cleared instead of being retried on every send forever.
+- fixed: Log the device and error when a push fails. The details were being passed to Pino in the wrong argument order, so every failure logged as a bare "Unknown error".
 
 ## 2.5.0 (2025-05-08)
 

--- a/pushServerConfig.sample.json
+++ b/pushServerConfig.sample.json
@@ -1,0 +1,7 @@
+{
+  "listenHost": "127.0.0.1",
+  "listenPort": 8008,
+  "amqpUri": "amqp://username:password@localhost:5672",
+  "couchUri": "http://username:password@localhost:5984",
+  "currentCluster": ""
+}

--- a/src/daemons/publishDaemon.ts
+++ b/src/daemons/publishDaemon.ts
@@ -9,6 +9,7 @@ import {
   getDevicesByLoginId
 } from '../db/couchDevices'
 import { DbConnections } from '../db/dbConnections'
+import { isUnregisteredToken } from '../util/firebaseErrors'
 import { logger } from '../util/logger'
 import { asRabbitMessage, SendableMessage } from '../util/pushSender'
 import { runDaemon } from './runDaemon'
@@ -88,12 +89,14 @@ async function sendToDevice(
       data: message.data ?? {}
     })
   } catch (error) {
-    if (String(error).includes('not a valid FCM registration token')) {
+    if (isUnregisteredToken(error)) {
       logger.info(`Disabling device: ${deviceId}`)
       deviceRow.device.deviceToken = undefined
       await deviceRow.save()
     } else {
-      logger.info('Unknown error', { deviceId, error })
+      // Pino takes the details first and the message second. Passing them the
+      // other way around silently drops them:
+      logger.info({ deviceId, error: String(error) }, 'Unknown error')
     }
   }
 }

--- a/src/db/couchApiKeys.ts
+++ b/src/db/couchApiKeys.ts
@@ -1,4 +1,4 @@
-import { asBoolean, asObject, asOptional, asString } from 'cleaners'
+import { asArray, asBoolean, asObject, asOptional, asString } from 'cleaners'
 import {
   asCouchDoc,
   asMaybeNotFoundError,
@@ -32,7 +32,9 @@ export const asCouchApiKey = asCouchDoc(
   asObject<CouchApiKey>({
     appId: asString,
     admin: asBoolean,
-    adminsdk: asOptional(asFirebaseAdminKey)
+    adminsdk: asOptional(asFirebaseAdminKey),
+    marketer: asOptional(asBoolean, false),
+    targetApiKeys: asOptional(asArray(asString), () => [])
   })
 )
 

--- a/src/db/couchDevices.ts
+++ b/src/db/couchDevices.ts
@@ -25,6 +25,10 @@ import { asBase64 } from '../types/pushCleaners'
 import { Device } from '../types/pushTypes'
 import { DbConnections } from './dbConnections'
 
+// Couch rejects an `_all_docs` request with no keys, and very large key lists
+// make for unwieldy requests, so batch lookups at this size:
+const FETCH_BATCH_SIZE = 500
+
 /**
  * A device returned from the database.
  * To make changes, edit the `device` object, then call `save`.
@@ -117,12 +121,35 @@ const locationByRegionDesign = makeJsDesign('locationByRegion', ({ emit }) => ({
   reduce: '_count'
 }))
 
+/**
+ * Looks up devices by API key, then by IP location.
+ */
+const apiKeyLocationDesign = makeJsDesign('apiKeyLocation', ({ emit }) => ({
+  map: function (doc) {
+    if (doc.apiKey == null || doc.location == null) return
+    emit(
+      [
+        doc.apiKey,
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        doc.location.country || '',
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        doc.location.region || '',
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        doc.location.city || ''
+      ],
+      null
+    )
+  },
+  reduce: '_count'
+}))
+
 export const couchDevicesSetup: DatabaseSetup = {
   name: 'push-devices',
   documents: {
     '_design/loginId': loginIdDesign,
     '_design/locationByCity': locationByCityDesign,
-    '_design/locationByRegion': locationByRegionDesign
+    '_design/locationByRegion': locationByRegionDesign,
+    '_design/apiKeyLocation': apiKeyLocationDesign
   }
 }
 
@@ -215,6 +242,33 @@ export async function getDeviceById(
 
   if (raw == null) return makeDeviceRow(db, emptyDevice)
   return makeDeviceRow(db, asCouchDevice(raw))
+}
+
+/**
+ * Looks up many devices at once, skipping any ids that are missing, deleted, or
+ * unreadable. Ids are de-duplicated, and the lookup runs in batches to keep
+ * individual Couch requests small.
+ */
+export async function fetchDevicesByIds(
+  connections: DbConnections,
+  deviceIds: string[]
+): Promise<DeviceRow[]> {
+  const db = connections.couch.use(couchDevicesSetup.name)
+  const unique = [...new Set(deviceIds)]
+
+  const out: DeviceRow[] = []
+  for (let i = 0; i < unique.length; i += FETCH_BATCH_SIZE) {
+    const keys = unique.slice(i, i + FETCH_BATCH_SIZE)
+    const response = await db.fetch({ keys })
+    for (const row of response.rows) {
+      // Missing and deleted ids come back as rows without a document:
+      if ('error' in row || row.doc == null) continue
+      const couchDevice = asMaybe(asCouchDevice)(row.doc)
+      if (couchDevice == null) continue
+      out.push(makeDeviceRow(db, couchDevice))
+    }
+  }
+  return out
 }
 
 /**
@@ -335,6 +389,49 @@ export async function* streamDevicesByLocation(
     return await db.view(viewName, viewName, {
       reduce: false,
       ...queryParams,
+      ...params
+    })
+  })) {
+    const couchDevice = asMaybe(asCouchDevice)(doc)
+    if (couchDevice == null) continue
+    yield makeDeviceRow(db, couchDevice)
+  }
+}
+
+/**
+ * Builds a CouchDB start key of [apiKey, country, region, city], stopping at the
+ * first missing location field so the range stays a valid prefix.
+ */
+function makeApiKeyLocationStartKey(
+  apiKey: string,
+  location: { country?: string; region?: string; city?: string }
+): string[] {
+  const key = [apiKey]
+  for (const part of [location.country, location.region, location.city]) {
+    if (part == null) break
+    key.push(part)
+  }
+  return key
+}
+
+/**
+ * Streams the devices registered under an API key, optionally narrowed by
+ * location.
+ */
+export async function* streamDevicesByApiKeyLocation(
+  connections: DbConnections,
+  apiKey: string,
+  location: { country?: string; region?: string; city?: string }
+): AsyncIterableIterator<DeviceRow> {
+  const db = connections.couch.use(couchDevicesSetup.name)
+  const startKey = makeApiKeyLocationStartKey(apiKey, location)
+  const endKey = [...startKey, 'zzzzzz']
+
+  for await (const doc of viewToStream(async params => {
+    return await db.view('apiKeyLocation', 'apiKeyLocation', {
+      reduce: false,
+      start_key: startKey,
+      end_key: endKey,
       ...params
     })
   })) {

--- a/src/db/couchDevices.ts
+++ b/src/db/couchDevices.ts
@@ -257,31 +257,43 @@ export async function getDeviceById(
   return makeDeviceRow(db, asCouchDevice(raw))
 }
 
+/** One batch of a by-id lookup, along with how far through the ids we are. */
+export interface DeviceBatch {
+  deviceRows: DeviceRow[]
+  /** How many of the requested ids have been read so far. */
+  idsRead: number
+}
+
 /**
  * Looks up many devices at once, skipping any ids that are missing, deleted, or
  * unreadable. Ids are de-duplicated, and the lookup runs in batches to keep
  * individual Couch requests small.
+ *
+ * This yields per batch rather than returning everything at once, so a caller
+ * working through hundreds of thousands of ids can report progress instead of
+ * going quiet for the whole lookup.
  */
-export async function fetchDevicesByIds(
+export async function* streamDeviceBatchesByIds(
   connections: DbConnections,
   deviceIds: string[]
-): Promise<DeviceRow[]> {
+): AsyncIterableIterator<DeviceBatch> {
   const db = connections.couch.use(couchDevicesSetup.name)
   const unique = [...new Set(deviceIds)]
 
-  const out: DeviceRow[] = []
   for (let i = 0; i < unique.length; i += FETCH_BATCH_SIZE) {
     const keys = unique.slice(i, i + FETCH_BATCH_SIZE)
     const response = await db.fetch({ keys })
+
+    const deviceRows: DeviceRow[] = []
     for (const row of response.rows) {
       // Missing and deleted ids come back as rows without a document:
       if ('error' in row || row.doc == null) continue
       const couchDevice = asMaybe(asCouchDevice)(row.doc)
       if (couchDevice == null) continue
-      out.push(makeDeviceRow(db, couchDevice))
+      deviceRows.push(makeDeviceRow(db, couchDevice))
     }
+    yield { deviceRows, idsRead: Math.min(i + keys.length, unique.length) }
   }
-  return out
 }
 
 /**

--- a/src/db/couchDevices.ts
+++ b/src/db/couchDevices.ts
@@ -123,6 +123,11 @@ const locationByRegionDesign = makeJsDesign('locationByRegion', ({ emit }) => ({
 
 /**
  * Looks up devices by API key, then by IP location.
+ *
+ * The row value carries everything an audience query needs to decide whether
+ * a device matches and to describe it, so the query never has to fetch the
+ * documents themselves. Devices with no location are absent from this view,
+ * and are therefore unreachable by location targeting.
  */
 const apiKeyLocationDesign = makeJsDesign('apiKeyLocation', ({ emit }) => ({
   map: function (doc) {
@@ -137,7 +142,15 @@ const apiKeyLocationDesign = makeJsDesign('apiKeyLocation', ({ emit }) => ({
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         doc.location.city || ''
       ],
-      null
+      {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        region: doc.location.region || '',
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        city: doc.location.city || '',
+        deviceToken: doc.deviceToken,
+        ignoreMarketing: doc.ignoreMarketing === true,
+        visited: doc.visited
+      }
     )
   },
   reduce: '_count'
@@ -415,28 +428,69 @@ function makeApiKeyLocationStartKey(
 }
 
 /**
- * Streams the devices registered under an API key, optionally narrowed by
- * location.
+ * What the `apiKeyLocation` view stores alongside each device, so that an
+ * audience query can work from the index alone.
  */
-export async function* streamDevicesByApiKeyLocation(
+export interface DeviceSummary {
+  deviceId: string
+  apiKey: string
+  region: string
+  city: string
+  deviceToken: string | undefined
+  ignoreMarketing: boolean
+  visited: Date
+}
+
+const asViewValue = asObject({
+  region: asOptional(asString, ''),
+  city: asOptional(asString, ''),
+  deviceToken: asOptional(asString),
+  ignoreMarketing: asOptional(asBoolean, false),
+  visited: asOptional(asDate, () => new Date(0))
+})
+
+// Rows to pull per request while paging through the view:
+const VIEW_PAGE_SIZE = 2048
+
+/**
+ * Streams a summary of every device registered under an API key, optionally
+ * narrowed by location.
+ *
+ * This reads the view rows only. Fetching the documents would mean pulling
+ * hundreds of megabytes to read a handful of fields, since the view spans a
+ * whole country and the location filters are applied afterwards.
+ */
+export async function* streamDeviceSummariesByApiKeyLocation(
   connections: DbConnections,
   apiKey: string,
   location: { country?: string; region?: string; city?: string }
-): AsyncIterableIterator<DeviceRow> {
+): AsyncIterableIterator<DeviceSummary> {
   const db = connections.couch.use(couchDevicesSetup.name)
   const startKey = makeApiKeyLocationStartKey(apiKey, location)
   const endKey = [...startKey, 'zzzzzz']
 
-  for await (const doc of viewToStream(async params => {
-    return await db.view('apiKeyLocation', 'apiKeyLocation', {
+  let params: object = { start_key: startKey }
+  while (true) {
+    const response = await db.view('apiKeyLocation', 'apiKeyLocation', {
       reduce: false,
-      start_key: startKey,
+      include_docs: false,
+      limit: VIEW_PAGE_SIZE,
       end_key: endKey,
       ...params
     })
-  })) {
-    const couchDevice = asMaybe(asCouchDevice)(doc)
-    if (couchDevice == null) continue
-    yield makeDeviceRow(db, couchDevice)
+    const { rows } = response
+    if (rows.length === 0) return
+
+    for (const row of rows) {
+      const value = asMaybe(asViewValue)(row.value)
+      if (value == null) continue
+      yield { ...value, deviceId: row.id, apiKey }
+    }
+
+    if (rows.length < VIEW_PAGE_SIZE) return
+    // Resume after the last row, which needs the doc id to break ties between
+    // devices sharing a location:
+    const last = rows[rows.length - 1]
+    params = { start_key: last.key, start_key_doc_id: last.id, skip: 1 }
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ import { makeExpressRoute } from 'serverlet/express'
 import { setupDatabases } from '../db/couchSetup'
 import { makeConnections, serverConfig } from '../serverConfig'
 import { logger } from '../util/logger'
+import { makeMarketingToolRouter } from './marketing/marketingTool'
 import { withLogging } from './middleware/withLogging'
 import { allRoutes } from './urls'
 
@@ -23,6 +24,12 @@ async function main(): Promise<void> {
   // Set up Express:
   const app = express()
   app.enable('trust proxy')
+
+  // The marketing tool API, mounted before the Serverlet catch-all. It comes
+  // ahead of the body parser below because it installs its own with a larger
+  // limit, and whichever parser runs first wins:
+  app.use('/marketing', makeMarketingToolRouter(connections))
+
   app.use(express.json({ limit: '1mb' }))
   app.use('/', makeExpressRoute(server))
 

--- a/src/server/marketing/locationFilter.ts
+++ b/src/server/marketing/locationFilter.ts
@@ -1,0 +1,99 @@
+import { Device } from '../../types/pushTypes'
+
+/**
+ * An include/exclude filter over the city and region a device is located in.
+ * The lists hold normalized values (see `parseLocationList`).
+ */
+export interface LocationFilter {
+  cityInclude: string[]
+  cityExclude: string[]
+  regionInclude: string[]
+  regionExclude: string[]
+}
+
+/**
+ * Why a device cannot receive a marketing push.
+ */
+export type DeviceSkipReason =
+  | 'ignore-marketing'
+  | 'unregistered'
+  | 'invalid-token'
+
+// Firebase tokens are alphanumerics plus these separators. Anything else is a
+// corrupt row that would only fail at delivery time:
+const VALID_TOKEN = /^[a-zA-Z0-9_\-:]+$/
+
+/**
+ * Normalizes one include/exclude box: each line is a separate value, blank
+ * lines are dropped, and matching is case-insensitive.
+ */
+export function parseLocationList(lines: string[]): string[] {
+  const out = new Set<string>()
+  for (const line of lines) {
+    const value = line.trim().toLowerCase()
+    if (value !== '') out.add(value)
+  }
+  return [...out]
+}
+
+/**
+ * Decides whether a device's location passes the filter. Values within one box
+ * are OR'd together, and the boxes are AND'ed with each other. An empty include
+ * box means "no restriction", while an empty exclude box excludes nothing.
+ *
+ * Country is deliberately absent: the caller selects it through the Couch view
+ * prefix, so re-checking it here could only disagree with the query.
+ */
+export function matchesLocationFilter(
+  location: Device['location'],
+  filter: LocationFilter
+): boolean {
+  if (location == null) return false
+  const city = location.city.trim().toLowerCase()
+  const region = location.region.trim().toLowerCase()
+
+  return (
+    passes(city, filter.cityInclude, filter.cityExclude) &&
+    passes(region, filter.regionInclude, filter.regionExclude)
+  )
+}
+
+function passes(value: string, include: string[], exclude: string[]): boolean {
+  if (include.length > 0 && !include.includes(value)) return false
+  return !exclude.includes(value)
+}
+
+/** The parts of a device that decide whether it can be sent to. */
+export type SendableFields = Pick<
+  Device,
+  'apiKey' | 'deviceToken' | 'ignoreMarketing'
+>
+
+/**
+ * Reports why a device cannot be sent to, or undefined if it can.
+ *
+ * The `targetApiKeys` are the app keys the marketing key may send to. Location
+ * queries get their scoping from the Couch view, but a send driven by a
+ * caller-supplied list of device ids does not, and the publish daemon resolves
+ * Firebase credentials from whatever key the device itself carries.
+ *
+ * This takes only the fields it reads so that queries can apply it to view
+ * rows, and sends to whole documents, without the two drifting apart.
+ */
+export function getDeviceSkipReason(
+  device: SendableFields,
+  targetApiKeys: ReadonlySet<string>
+): DeviceSkipReason | undefined {
+  const { apiKey, deviceToken, ignoreMarketing } = device
+
+  if (ignoreMarketing) return 'ignore-marketing'
+  if (
+    apiKey == null ||
+    !targetApiKeys.has(apiKey) ||
+    deviceToken == null ||
+    deviceToken.trim() === ''
+  ) {
+    return 'unregistered'
+  }
+  if (!VALID_TOKEN.test(deviceToken)) return 'invalid-token'
+}

--- a/src/server/marketing/marketingTool.ts
+++ b/src/server/marketing/marketingTool.ts
@@ -4,15 +4,14 @@ import express, { NextFunction, Request, Response, Router } from 'express'
 
 import { getApiKeyByKey } from '../../db/couchApiKeys'
 import {
-  fetchDevicesByIds,
   getDeviceById,
   getDevicesByLoginId,
+  streamDeviceBatchesByIds,
   streamDeviceSummariesByApiKeyLocation
 } from '../../db/couchDevices'
 import { DbConnections } from '../../db/dbConnections'
 import { asBase64 } from '../../types/pushCleaners'
 import { ApiKey, Device } from '../../types/pushTypes'
-import { makeHeartbeat } from '../../util/heartbeat'
 import { makePushSender, SendableMessage } from '../../util/pushSender'
 import {
   getDeviceSkipReason,
@@ -20,6 +19,7 @@ import {
   matchesLocationFilter,
   parseLocationList
 } from './locationFilter'
+import { makeProgressLog } from './progress'
 
 const asTestMessageBody = asObject({
   deviceId: asOptional(asString),
@@ -61,6 +61,9 @@ const BODY_LIMIT = '64mb'
 // the entire targetable population, so ordinary country-wide sends never meet
 // it. Raise it before it starts rejecting real audiences.
 const MAX_QUERY_DEVICES = 2_000_000
+
+// How often a long send reports how far along it is:
+const PROGRESS_INTERVAL_MS = 30_000
 
 /**
  * Builds an Express router with the marketing tool API endpoints: `test` sends
@@ -307,51 +310,62 @@ export function makeMarketingToolRouter(connections: DbConnections): Router {
           isMarketing: true,
           isPriceChange: false
         }
-        const heartbeat = makeHeartbeat({ write }, { logSeconds: 2 })
-
         write(`Loading ${deviceIds.length} devices...\n`)
 
         // Re-read the documents, since a device may have opted out or been
         // deleted since the caller queried it. The publish daemon repeats these
         // checks when it drains the queue, so this is about reporting an honest
         // count rather than about enforcement.
+        const loading = makeProgressLog(write, 'Loaded', deviceIds.length, {
+          intervalMs: PROGRESS_INTERVAL_MS
+        })
         const devices = new Map<string, Device>()
         let skipped = 0
-        for (const deviceRow of await fetchDevicesByIds(
+        let invalidTokens = 0
+        for await (const batch of streamDeviceBatchesByIds(
           connections,
           deviceIds
         )) {
-          const { device } = deviceRow
-          const reason = getDeviceSkipReason(device, targets)
-          if (reason != null) {
-            if (reason === 'invalid-token') {
-              write(
-                `Invalid token '${String(device.deviceToken)}' for doc '${
-                  device.deviceId
-                }'\n`
-              )
+          for (const { device } of batch.deviceRows) {
+            const reason = getDeviceSkipReason(device, targets)
+            if (reason != null) {
+              // One line per bad token would bury the progress log, so count
+              // them and report the total instead:
+              if (reason === 'invalid-token') ++invalidTokens
+              ++skipped
+              continue
             }
-            ++skipped
-            continue
+            devices.set(device.deviceId, device)
           }
-          devices.set(device.deviceId, device)
-          heartbeat(`Reached ${device.deviceId}`)
+          loading.update(batch.idsRead)
+        }
+        loading.finish(deviceIds.length)
+        if (invalidTokens > 0) {
+          write(`  ${invalidTokens} devices had an unusable token\n`)
         }
 
         const missing = deviceIds.length - devices.size - skipped
         write(
-          `Sending to ${devices.size} devices` +
+          `Queueing ${devices.size} devices` +
             ` (${skipped} skipped, ${missing} no longer found)...\n`
         )
+        const queueing = makeProgressLog(write, 'Queued', devices.size, {
+          intervalMs: PROGRESS_INTERVAL_MS
+        })
+        let queued = 0
         for (const device of devices.values()) {
           const { deviceId } = device
           await sender.sendToDevice(device, message).catch((error: unknown) => {
             write(`Device ${deviceId} failed: ${String(error)}\n`)
           })
-          heartbeat(`Reached ${deviceId}`)
+          queueing.update(++queued)
         }
+        queueing.finish(queued)
 
-        write('\n[DONE] Marketing send complete.\n')
+        // Deliberately not "sent": this hands the messages to the queue, and
+        // the publish daemon delivers them afterwards, which for a large
+        // audience runs long after this response ends.
+        write(`\n[DONE] ${devices.size} devices queued for delivery.\n`)
       } catch (error: unknown) {
         write(
           `\n[ERROR] ${

--- a/src/server/marketing/marketingTool.ts
+++ b/src/server/marketing/marketingTool.ts
@@ -1,0 +1,429 @@
+import { asArray, asBoolean, asObject, asOptional, asString } from 'cleaners'
+import { randomUUID } from 'crypto'
+import express, { NextFunction, Request, Response, Router } from 'express'
+
+import { getApiKeyByKey } from '../../db/couchApiKeys'
+import {
+  fetchDevicesByIds,
+  getDeviceById,
+  getDevicesByLoginId,
+  streamDeviceSummariesByApiKeyLocation
+} from '../../db/couchDevices'
+import { DbConnections } from '../../db/dbConnections'
+import { asBase64 } from '../../types/pushCleaners'
+import { ApiKey, Device } from '../../types/pushTypes'
+import { makeHeartbeat } from '../../util/heartbeat'
+import { makePushSender, SendableMessage } from '../../util/pushSender'
+import {
+  getDeviceSkipReason,
+  LocationFilter,
+  matchesLocationFilter,
+  parseLocationList
+} from './locationFilter'
+
+const asTestMessageBody = asObject({
+  deviceId: asOptional(asString),
+  loginId: asOptional(asBase64),
+  title: asOptional(asString, 'Test Message'),
+  body: asString,
+  url: asOptional(asString)
+})
+
+// Test pushes carry this fixed campaign id (rather than a generated one) so the
+// app treats them as marketing notifications and navigates, while their opens
+// stay distinguishable from real campaigns in analytics.
+const TEST_CAMPAIGN_ID = 'test'
+
+const asStringList = asOptional(asArray(asString), () => [])
+
+const asQueryDevicesBody = asObject({
+  country: asString,
+  cityInclude: asStringList,
+  cityExclude: asStringList,
+  regionInclude: asStringList,
+  regionExclude: asStringList
+})
+
+const asPushToDevicesBody = asObject({
+  deviceIds: asArray(asString),
+  title: asOptional(asString),
+  body: asOptional(asString),
+  url: asOptional(asString),
+  confirmed: asOptional(asBoolean, false)
+})
+
+// A send carries one device id per targeted device, so its body dwarfs the 1mb
+// the public endpoints allow. A whole-country audience currently runs to a few
+// hundred thousand ids at ~26 characters each, so leave generous headroom:
+const BODY_LIMIT = '64mb'
+
+// A backstop against a runaway audience, not a product limit: this sits above
+// the entire targetable population, so ordinary country-wide sends never meet
+// it. Raise it before it starts rejecting real audiences.
+const MAX_QUERY_DEVICES = 2_000_000
+
+/**
+ * Builds an Express router with the marketing tool API endpoints: `test` sends
+ * a single test push, `query` lists the devices a send would reach, and `push`
+ * sends to the device list a query returned. The web UI is hosted separately by
+ * the internal tools project, which supplies the key.
+ *
+ * Every endpoint requires an `x-api-key` header naming a key with the
+ * `marketer` (or `admin`) flag, and only reaches devices registered under the
+ * keys in that key's `targetApiKeys` list. The apps' own keys deliberately
+ * cannot call these endpoints: they ship inside the apps, so anyone holding
+ * one could otherwise push to that app's whole audience.
+ */
+export function makeMarketingToolRouter(connections: DbConnections): Router {
+  const router = Router()
+
+  // The API key travels in a header, so check it before parsing any body.
+  // Otherwise anonymous callers could make the server chew through
+  // BODY_LIMIT-sized bodies just to be told 401:
+  router.use((req: Request, res: Response, next: NextFunction): void => {
+    authenticate(connections, req, res)
+      .then(apiKeyRow => {
+        if (apiKeyRow == null) return // authenticate already responded
+        res.locals.apiKeyRow = apiKeyRow
+        next()
+      })
+      .catch((error: unknown) => {
+        if (!res.headersSent) {
+          res.status(500).json({
+            error: error instanceof Error ? error.message : String(error)
+          })
+        }
+      })
+  })
+
+  // This router parses its own bodies, since a device-id list is far larger
+  // than anything the public endpoints accept:
+  router.use(express.json({ limit: BODY_LIMIT }))
+
+  // Wraps the `send-message` command for sending a single test push.
+  router.post(
+    '/test',
+    asyncRoute(async (req: Request, res: Response): Promise<void> => {
+      const apiKeyRow: ApiKey = res.locals.apiKeyRow
+      const targets = getTargets(apiKeyRow, res)
+      if (targets == null) return
+
+      let parsed
+      try {
+        parsed = asTestMessageBody(req.body)
+      } catch (error: unknown) {
+        res.status(400).json({
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return
+      }
+      const { deviceId, loginId, title, body, url } = parsed
+
+      try {
+        if (body.trim() === '') {
+          res.status(400).json({ error: 'Message body is required.' })
+          return
+        }
+
+        const sender = makePushSender(connections)
+        const data: { [key: string]: string } = {
+          type: 'marketing',
+          campaignId: TEST_CAMPAIGN_ID
+        }
+        if (url != null) data.url = url
+        const message: SendableMessage = {
+          title,
+          body,
+          data,
+          isMarketing: false, // This tool is used for testing
+          isPriceChange: false
+        }
+
+        if (loginId != null) {
+          // A login can span apps, so resolve its devices here and keep the
+          // targeted ones, rather than letting the publish daemon fan out to
+          // every app the login has touched:
+          const deviceRows = await getDevicesByLoginId(connections, loginId)
+          const devices = deviceRows
+            .map(row => row.device)
+            .filter(
+              device => device.apiKey != null && targets.has(device.apiKey)
+            )
+          if (devices.length === 0) {
+            res.status(400).json({
+              error: 'Login has no devices under a targeted api key.'
+            })
+            return
+          }
+          for (const device of devices) {
+            await sender.sendToDevice(device, message)
+          }
+        } else if (deviceId != null) {
+          const deviceRow = await getDeviceById(
+            connections,
+            deviceId,
+            new Date()
+          )
+          const deviceApiKey = deviceRow.device.apiKey
+          if (deviceApiKey == null || !targets.has(deviceApiKey)) {
+            res.status(400).json({
+              error: 'Device is not registered under a targeted api key.'
+            })
+            return
+          }
+          await sender.sendToDevice(deviceRow.device, message)
+        } else {
+          res.status(400).json({ error: 'No deviceId or loginId' })
+          return
+        }
+
+        res.status(200).json({ success: true })
+      } catch (error: unknown) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    })
+  )
+
+  // Lists the devices a marketing send would reach, so the caller can review
+  // the audience before committing to it. Read-only.
+  router.post(
+    '/query',
+    asyncRoute(async (req: Request, res: Response): Promise<void> => {
+      const apiKeyRow: ApiKey = res.locals.apiKeyRow
+      const targets = getTargets(apiKeyRow, res)
+      if (targets == null) return
+
+      let parsed
+      try {
+        parsed = asQueryDevicesBody(req.body)
+      } catch (error: unknown) {
+        res.status(400).json({
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return
+      }
+      const { country } = parsed
+      const filter: LocationFilter = {
+        cityInclude: parseLocationList(parsed.cityInclude),
+        cityExclude: parseLocationList(parsed.cityExclude),
+        regionInclude: parseLocationList(parsed.regionInclude),
+        regionExclude: parseLocationList(parsed.regionExclude)
+      }
+
+      const devices = []
+      for (const target of targets) {
+        for await (const summary of streamDeviceSummariesByApiKeyLocation(
+          connections,
+          target,
+          { country }
+        )) {
+          if (getDeviceSkipReason(summary, targets) != null) continue
+          const { region, city } = summary
+          if (!matchesLocationFilter({ country, region, city }, filter))
+            continue
+
+          if (devices.length >= MAX_QUERY_DEVICES) {
+            res.status(413).json({
+              error:
+                `More than ${MAX_QUERY_DEVICES} devices match. ` +
+                'Narrow the audience and query again.'
+            })
+            return
+          }
+          devices.push({
+            deviceId: summary.deviceId,
+            region,
+            city,
+            visited: summary.visited
+          })
+        }
+      }
+
+      res.status(200).json({ total: devices.length, devices })
+    })
+  )
+
+  // Sends to an explicit list of devices, as returned by `query`. The send
+  // deliberately takes device ids rather than a location: the caller reviews
+  // exactly this list first, and a server that predates a body field would
+  // silently drop it, whereas an unknown route fails loudly.
+  router.post(
+    '/push',
+    asyncRoute(async (req: Request, res: Response): Promise<void> => {
+      const apiKeyRow: ApiKey = res.locals.apiKeyRow
+      const targets = getTargets(apiKeyRow, res)
+      if (targets == null) return
+
+      let parsed
+      try {
+        parsed = asPushToDevicesBody(req.body)
+      } catch (error: unknown) {
+        res.status(400).json({
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return
+      }
+      const { deviceIds, title, body, url, confirmed } = parsed
+
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+      res.flushHeaders()
+      const write = (chunk: string): void => {
+        res.write(chunk)
+      }
+
+      try {
+        if (!confirmed) {
+          write('[ERROR] Confirmation required before sending.\n')
+          return
+        }
+        if (body == null || title == null) {
+          write('Nothing sent. No title or body for message.\n')
+          write('[ERROR] Missing title or body.\n')
+          return
+        }
+        if (deviceIds.length === 0) {
+          write('Nothing sent. The device list is empty.\n')
+          write('[ERROR] No devices selected.\n')
+          return
+        }
+
+        // A unique id for this campaign, echoed in each notification so the app
+        // can report opens back to our analytics:
+        const campaignId = randomUUID()
+        write(`[campaign] ${campaignId}\n`)
+
+        const sender = makePushSender(connections)
+        const data: { [key: string]: string } = {
+          type: 'marketing',
+          campaignId
+        }
+        if (url != null) data.url = url
+        const message: SendableMessage = {
+          title,
+          body,
+          data,
+          isMarketing: true,
+          isPriceChange: false
+        }
+        const heartbeat = makeHeartbeat({ write }, { logSeconds: 2 })
+
+        write(`Loading ${deviceIds.length} devices...\n`)
+
+        // Re-read the documents, since a device may have opted out or been
+        // deleted since the caller queried it. The publish daemon repeats these
+        // checks when it drains the queue, so this is about reporting an honest
+        // count rather than about enforcement.
+        const devices = new Map<string, Device>()
+        let skipped = 0
+        for (const deviceRow of await fetchDevicesByIds(
+          connections,
+          deviceIds
+        )) {
+          const { device } = deviceRow
+          const reason = getDeviceSkipReason(device, targets)
+          if (reason != null) {
+            if (reason === 'invalid-token') {
+              write(
+                `Invalid token '${String(device.deviceToken)}' for doc '${
+                  device.deviceId
+                }'\n`
+              )
+            }
+            ++skipped
+            continue
+          }
+          devices.set(device.deviceId, device)
+          heartbeat(`Reached ${device.deviceId}`)
+        }
+
+        const missing = deviceIds.length - devices.size - skipped
+        write(
+          `Sending to ${devices.size} devices` +
+            ` (${skipped} skipped, ${missing} no longer found)...\n`
+        )
+        for (const device of devices.values()) {
+          const { deviceId } = device
+          await sender.sendToDevice(device, message).catch((error: unknown) => {
+            write(`Device ${deviceId} failed: ${String(error)}\n`)
+          })
+          heartbeat(`Reached ${deviceId}`)
+        }
+
+        write('\n[DONE] Marketing send complete.\n')
+      } catch (error: unknown) {
+        write(
+          `\n[ERROR] ${
+            error instanceof Error ? error.message : String(error)
+          }\n`
+        )
+      } finally {
+        res.end()
+      }
+    })
+  )
+
+  return router
+}
+
+/**
+ * Validates the `x-api-key` header against the API-key database, and requires
+ * the `marketer` (or `admin`) flag. On failure it responds with a 401 or 403
+ * and returns undefined, so callers should bail out.
+ */
+async function authenticate(
+  connections: DbConnections,
+  req: Request,
+  res: Response
+): Promise<ApiKey | undefined> {
+  const key = req.header('x-api-key')
+  const apiKeyRow =
+    key == null ? undefined : await getApiKeyByKey(connections, key)
+  if (apiKeyRow == null) {
+    res.status(401).json({ error: 'Invalid or missing API key.' })
+    return undefined
+  }
+  if (!apiKeyRow.marketer && !apiKeyRow.admin) {
+    res.status(403).json({ error: 'API key is not allowed to send marketing.' })
+    return undefined
+  }
+  return apiKeyRow
+}
+
+/**
+ * Reads the app keys a marketing key may send to. A key with none configured
+ * cannot target anything, which fails closed: responds with a 400 and returns
+ * undefined, so callers should bail out.
+ */
+function getTargets(apiKeyRow: ApiKey, res: Response): Set<string> | undefined {
+  const targets = new Set(apiKeyRow.targetApiKeys)
+  if (targets.size === 0) {
+    res.status(400).json({
+      error: 'API key has no targetApiKeys configured.'
+    })
+    return undefined
+  }
+  return targets
+}
+
+/**
+ * Wraps an async Express handler so the router receives a synchronous
+ * void-returning function (satisfying the handler type) while still reporting
+ * any unexpected rejection back to the client.
+ */
+function asyncRoute(
+  handler: (req: Request, res: Response) => Promise<void>
+): (req: Request, res: Response) => void {
+  return (req, res) => {
+    handler(req, res).catch((error: unknown) => {
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : String(error)
+        })
+      } else {
+        res.end()
+      }
+    })
+  }
+}

--- a/src/server/marketing/progress.ts
+++ b/src/server/marketing/progress.ts
@@ -1,0 +1,72 @@
+interface ProgressOptions {
+  /** How often to emit a line, in milliseconds. */
+  intervalMs?: number
+  /** Injectable clock, for tests. */
+  now?: () => number
+}
+
+export interface ProgressLog {
+  /** Reports how far along we are, emitting at most once per interval. */
+  update: (done: number) => void
+  /** Emits a closing line regardless of when the last one went out. */
+  finish: (done: number) => void
+}
+
+/**
+ * Reports progress through a long job on a fixed schedule, rather than once
+ * per item. A marketing send walks hundreds of thousands of devices, so the
+ * caller needs to know how far along it is and roughly how long is left.
+ */
+export function makeProgressLog(
+  write: (chunk: string) => void,
+  label: string,
+  total: number,
+  options: ProgressOptions = {}
+): ProgressLog {
+  const { intervalMs = 30_000, now = () => Date.now() } = options
+
+  const start = now()
+  let nextAt = intervalMs
+
+  const emit = (done: number, final: boolean): void => {
+    const elapsedMs = now() - start
+    const percent = total <= 0 ? 100 : Math.floor((100 * done) / total)
+    const perSecond = elapsedMs > 0 ? done / (elapsedMs / 1000) : 0
+
+    let line = `  ${label}: ${percent}% — ${commas(done)} of ${commas(total)}`
+    if (!final && perSecond > 0) {
+      const remaining = (total - done) / perSecond
+      line += ` (${commas(Math.round(perSecond))}/s, ~${duration(
+        remaining
+      )} left)`
+    } else if (final) {
+      line += ` in ${duration(elapsedMs / 1000)}`
+    }
+    write(`${line}\n`)
+  }
+
+  return {
+    update(done: number): void {
+      const elapsedMs = now() - start
+      if (elapsedMs < nextAt) return
+      // Skip whole intervals rather than emitting a burst after a long stall:
+      while (nextAt <= elapsedMs) nextAt += intervalMs
+      emit(done, false)
+    },
+    finish(done: number): void {
+      emit(done, true)
+    }
+  }
+}
+
+function commas(value: number): string {
+  return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+function duration(seconds: number): string {
+  if (!isFinite(seconds) || seconds < 0) return '?'
+  if (seconds < 90) return `${Math.round(seconds)}s`
+  const minutes = seconds / 60
+  if (minutes < 90) return `${Math.round(minutes)}m`
+  return `${(minutes / 60).toFixed(1)}h`
+}

--- a/src/types/pushTypes.ts
+++ b/src/types/pushTypes.ts
@@ -27,6 +27,16 @@ export interface ApiKey {
 
   admin: boolean
   adminsdk?: FirebaseAdminKey
+
+  /** May this key call the marketing endpoints? */
+  marketer: boolean
+
+  /**
+   * The api keys whose devices this key may send marketing pushes to.
+   * Devices are registered under the key baked into each app, so a separate
+   * marketing key needs this list to say which apps it is allowed to target.
+   */
+  targetApiKeys: string[]
 }
 
 /**

--- a/src/util/firebaseErrors.ts
+++ b/src/util/firebaseErrors.ts
@@ -1,0 +1,29 @@
+/**
+ * True when Firebase reports that a token no longer belongs to an installed
+ * app, so the device can never receive anything until it registers again.
+ *
+ * How this arrives has changed between Firebase versions: the newer API sets a
+ * `messaging/registration-token-not-registered` code, the legacy API stringifies
+ * to `Error: NotRegistered`, and older releases used a sentence. Match all
+ * three, since missing it means the dead token is retried on every send
+ * forever, and never gets cleaned up.
+ */
+export function isUnregisteredToken(error: unknown): boolean {
+  if (typeof error === 'object' && error !== null) {
+    const { code, errorInfo } = error as {
+      code?: string
+      errorInfo?: { code?: string }
+    }
+    if (
+      (errorInfo?.code ?? code) ===
+      'messaging/registration-token-not-registered'
+    ) {
+      return true
+    }
+  }
+  const text = String(error)
+  return (
+    text.includes('NotRegistered') ||
+    text.includes('not a valid FCM registration token')
+  )
+}

--- a/test/firebaseErrors.test.ts
+++ b/test/firebaseErrors.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { isUnregisteredToken } from '../src/util/firebaseErrors'
+
+describe('isUnregisteredToken', function () {
+  it('matches the error code the current Firebase SDK reports', function () {
+    const error = Object.assign(new Error('Requested entity was not found.'), {
+      errorInfo: { code: 'messaging/registration-token-not-registered' }
+    })
+    expect(isUnregisteredToken(error)).equals(true)
+  })
+
+  it('matches a bare code property', function () {
+    const error = Object.assign(new Error('nope'), {
+      code: 'messaging/registration-token-not-registered'
+    })
+    expect(isUnregisteredToken(error)).equals(true)
+  })
+
+  it('matches what the legacy send API stringifies to', function () {
+    // This is the exact shape seen in production against firebase-admin 8:
+    expect(isUnregisteredToken(new Error('NotRegistered'))).equals(true)
+  })
+
+  it('still matches the original wording', function () {
+    expect(
+      isUnregisteredToken(
+        new Error('abc is not a valid FCM registration token')
+      )
+    ).equals(true)
+  })
+
+  it('leaves other failures alone, so a device is never disabled by mistake', function () {
+    const cases: unknown[] = [
+      new Error('Requested entity was not found'), // no code: too vague to act on
+      Object.assign(new Error('quota'), {
+        errorInfo: { code: 'messaging/quota-exceeded' }
+      }),
+      Object.assign(new Error('unavailable'), {
+        errorInfo: { code: 'messaging/server-unavailable' }
+      }),
+      new Error('socket hang up'),
+      'a plain string',
+      undefined,
+      null
+    ]
+    for (const error of cases) {
+      expect(isUnregisteredToken(error), String(error)).equals(false)
+    }
+  })
+})

--- a/test/locationFilter.test.ts
+++ b/test/locationFilter.test.ts
@@ -1,0 +1,215 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import {
+  getDeviceSkipReason,
+  LocationFilter,
+  matchesLocationFilter,
+  parseLocationList
+} from '../src/server/marketing/locationFilter'
+import { Device } from '../src/types/pushTypes'
+
+const emptyFilter: LocationFilter = {
+  cityInclude: [],
+  cityExclude: [],
+  regionInclude: [],
+  regionExclude: []
+}
+
+const makeFilter = (parts: Partial<LocationFilter>): LocationFilter => ({
+  ...emptyFilter,
+  ...parts
+})
+
+const makeLocation = (city: string, region: string): Device['location'] => ({
+  country: 'United States',
+  city,
+  region
+})
+
+const nyc = makeLocation('New York', 'NY')
+const buffalo = makeLocation('Buffalo', 'NY')
+const sanDiego = makeLocation('San Diego', 'CA')
+
+describe('parseLocationList', function () {
+  it('trims, lowercases, and drops blank lines', function () {
+    expect(parseLocationList([' New York ', '', '   ', 'BUFFALO'])).deep.equals(
+      ['new york', 'buffalo']
+    )
+  })
+
+  it('removes duplicates', function () {
+    expect(parseLocationList(['NY', 'ny', ' Ny '])).deep.equals(['ny'])
+  })
+})
+
+describe('matchesLocationFilter', function () {
+  it('passes everything when no filters are set', function () {
+    expect(matchesLocationFilter(nyc, emptyFilter)).equals(true)
+  })
+
+  it('rejects devices with no location', function () {
+    expect(matchesLocationFilter(undefined, emptyFilter)).equals(false)
+  })
+
+  it('treats each include line as an alternative', function () {
+    const filter = makeFilter({ cityInclude: ['buffalo', 'san diego'] })
+    expect(matchesLocationFilter(buffalo, filter)).equals(true)
+    expect(matchesLocationFilter(sanDiego, filter)).equals(true)
+    expect(matchesLocationFilter(nyc, filter)).equals(false)
+  })
+
+  it('treats each exclude line as an alternative', function () {
+    const filter = makeFilter({ cityExclude: ['buffalo', 'san diego'] })
+    expect(matchesLocationFilter(buffalo, filter)).equals(false)
+    expect(matchesLocationFilter(sanDiego, filter)).equals(false)
+    expect(matchesLocationFilter(nyc, filter)).equals(true)
+  })
+
+  it('lets an exclude override an include', function () {
+    const filter = makeFilter({
+      cityInclude: ['new york', 'buffalo'],
+      cityExclude: ['buffalo']
+    })
+    expect(matchesLocationFilter(nyc, filter)).equals(true)
+    expect(matchesLocationFilter(buffalo, filter)).equals(false)
+  })
+
+  it('ANDs the city and region filters together', function () {
+    const filter = makeFilter({
+      cityInclude: ['buffalo'],
+      regionExclude: ['ny']
+    })
+    expect(matchesLocationFilter(buffalo, filter)).equals(false)
+    expect(matchesLocationFilter(makeLocation('Buffalo', 'WY'), filter)).equals(
+      true
+    )
+  })
+
+  it('matches regions by their stored two-letter code', function () {
+    const filter = makeFilter({ regionInclude: ['ny'] })
+    expect(matchesLocationFilter(nyc, filter)).equals(true)
+    expect(matchesLocationFilter(sanDiego, filter)).equals(false)
+
+    // Region names are not aliased to codes:
+    expect(
+      matchesLocationFilter(nyc, makeFilter({ regionInclude: ['new york'] }))
+    ).equals(false)
+  })
+
+  it('ignores case and surrounding whitespace on both sides', function () {
+    const filter = makeFilter({ cityExclude: ['new york'] })
+    expect(
+      matchesLocationFilter(makeLocation('  NEW YORK ', 'NY'), filter)
+    ).equals(false)
+  })
+
+  it('handles devices with a blank region', function () {
+    const blank = makeLocation('Buffalo', '')
+    expect(
+      matchesLocationFilter(blank, makeFilter({ regionInclude: ['ny'] }))
+    ).equals(false)
+    expect(
+      matchesLocationFilter(blank, makeFilter({ regionExclude: ['ny'] }))
+    ).equals(true)
+  })
+
+  it('excludes New York from a nationwide send', function () {
+    // "United States, exclude New York, empty Region boxes"
+    const filter = makeFilter({ cityExclude: ['new york'] })
+    expect(matchesLocationFilter(nyc, filter)).equals(false)
+    expect(matchesLocationFilter(buffalo, filter)).equals(true)
+    expect(matchesLocationFilter(sanDiego, filter)).equals(true)
+  })
+
+  it('matches nothing when the city and region filters conflict', function () {
+    // "include New York City, Region exclude NY". Devices store the city as
+    // "New York", so the include alone already matches nothing.
+    const filter = makeFilter({
+      cityInclude: ['new york city'],
+      regionExclude: ['ny']
+    })
+    for (const location of [nyc, buffalo, sanDiego]) {
+      expect(matchesLocationFilter(location, filter)).equals(false)
+    }
+  })
+})
+
+describe('getDeviceSkipReason', function () {
+  const targets = new Set(['edge-app-key', 'white-label-key'])
+  const makeDevice = (parts: Partial<Device> = {}): Device => ({
+    created: new Date(),
+    deviceId: 'device-1',
+    apiKey: 'edge-app-key',
+    deviceToken: 'valid-token:123',
+    ignoreMarketing: false,
+    ignorePriceChanges: false,
+    loginIds: [],
+    visited: new Date(),
+    ...parts
+  })
+
+  it('accepts a sendable device under any targeted key', function () {
+    expect(getDeviceSkipReason(makeDevice(), targets)).equals(undefined)
+    expect(
+      getDeviceSkipReason(makeDevice({ apiKey: 'white-label-key' }), targets)
+    ).equals(undefined)
+  })
+
+  it('skips devices that opted out of marketing', function () {
+    expect(
+      getDeviceSkipReason(makeDevice({ ignoreMarketing: true }), targets)
+    ).equals('ignore-marketing')
+  })
+
+  it('skips devices outside the targeted API keys', function () {
+    expect(
+      getDeviceSkipReason(makeDevice({ apiKey: 'other-key' }), targets)
+    ).equals('unregistered')
+    expect(
+      getDeviceSkipReason(makeDevice({ apiKey: undefined }), targets)
+    ).equals('unregistered')
+    expect(getDeviceSkipReason(makeDevice(), new Set())).equals('unregistered')
+  })
+
+  it('skips devices with a missing or blank token', function () {
+    expect(
+      getDeviceSkipReason(makeDevice({ deviceToken: undefined }), targets)
+    ).equals('unregistered')
+    expect(
+      getDeviceSkipReason(makeDevice({ deviceToken: '   ' }), targets)
+    ).equals('unregistered')
+  })
+
+  it('skips devices with a malformed token', function () {
+    expect(
+      getDeviceSkipReason(makeDevice({ deviceToken: 'has spaces' }), targets)
+    ).equals('invalid-token')
+    expect(
+      getDeviceSkipReason(makeDevice({ deviceToken: 'back\\slash' }), targets)
+    ).equals('invalid-token')
+  })
+
+  it('judges a view summary the same as a whole document', function () {
+    // The audience query applies this to `apiKeyLocation` view rows while the
+    // send applies it to documents, so both shapes must reach the same answer:
+    const cases: Array<Partial<Device>> = [
+      {},
+      { ignoreMarketing: true },
+      { apiKey: 'other-key' },
+      { deviceToken: undefined },
+      { deviceToken: 'has spaces' }
+    ]
+    for (const parts of cases) {
+      const device = makeDevice(parts)
+      const summary = {
+        apiKey: device.apiKey,
+        deviceToken: device.deviceToken,
+        ignoreMarketing: device.ignoreMarketing
+      }
+      expect(getDeviceSkipReason(summary, targets)).equals(
+        getDeviceSkipReason(device, targets)
+      )
+    }
+  })
+})

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { makeProgressLog, ProgressLog } from '../src/server/marketing/progress'
+
+interface Harness {
+  lines: string[]
+  log: ProgressLog
+  tick: (ms: number) => number
+}
+
+/** Collects written lines, with a clock the test drives by hand. */
+const setup = (total: number, intervalMs = 30_000): Harness => {
+  const lines: string[] = []
+  let clock = 0
+  const log = makeProgressLog(
+    chunk => lines.push(chunk.replace(/\n$/, '')),
+    'Queued',
+    total,
+    { intervalMs, now: () => clock }
+  )
+  return { lines, log, tick: (ms: number) => (clock += ms) }
+}
+
+describe('makeProgressLog', function () {
+  it('says nothing before the first interval elapses', function () {
+    const { lines, log, tick } = setup(1000)
+    log.update(100)
+    tick(29_000)
+    log.update(500)
+    expect(lines).deep.equals([])
+  })
+
+  it('reports a percentage once the interval passes', function () {
+    const { lines, log, tick } = setup(1000)
+    tick(30_000)
+    log.update(250)
+    expect(lines).lengthOf(1)
+    expect(lines[0]).contains('Queued: 25%')
+    expect(lines[0]).contains('250 of 1,000')
+  })
+
+  it('emits at most one line per interval', function () {
+    const { lines, log, tick } = setup(1000)
+    tick(30_000)
+    log.update(250)
+    log.update(300)
+    log.update(400)
+    expect(lines).lengthOf(1)
+    tick(30_000)
+    log.update(600)
+    expect(lines).lengthOf(2)
+    expect(lines[1]).contains('60%')
+  })
+
+  it('does not emit a burst after a long stall', function () {
+    const { lines, log, tick } = setup(1000)
+    // Five intervals pass with no updates at all:
+    tick(150_000)
+    log.update(900)
+    expect(lines).lengthOf(1)
+  })
+
+  it('includes a rate and an estimate of the time left', function () {
+    const { lines, log, tick } = setup(1000)
+    tick(30_000) // 300 done in 30s = 10/s, 700 left = 70s
+    log.update(300)
+    expect(lines[0]).contains('10/s')
+    expect(lines[0]).contains('70s left')
+  })
+
+  it('closes with a total and elapsed time, and no estimate', function () {
+    const { lines, log, tick } = setup(1000)
+    tick(50_000)
+    log.finish(1000)
+    expect(lines).lengthOf(1)
+    expect(lines[0]).contains('100%')
+    expect(lines[0]).contains('1,000 of 1,000')
+    expect(lines[0]).contains('in 50s')
+    expect(lines[0]).does.not.contain('left')
+  })
+
+  it('formats long estimates in minutes and hours', function () {
+    const a = setup(1_000_000)
+    a.tick(30_000) // 10k in 30s = 333/s -> ~2970s left
+    a.log.update(10_000)
+    expect(a.lines[0]).contains('m left')
+
+    const b = setup(100_000_000)
+    b.tick(30_000)
+    b.log.update(10_000)
+    expect(b.lines[0]).contains('h left')
+  })
+
+  it('survives an empty job without dividing by zero', function () {
+    const { lines, log } = setup(0)
+    log.finish(0)
+    expect(lines[0]).contains('100%')
+    expect(lines[0]).does.not.contain('NaN')
+    expect(lines[0]).does.not.contain('Infinity')
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Adds the marketing tool API consumed by the web UI in EdgeApp/edge-internal-tools#1, in three pieces:

- **DB helpers**: an `apiKeyLocation` view keyed `[apiKey, country, region, city]` with a streaming reader, plus a batched-by-id device lookup.
- **Marketer keys**: API keys gain a `marketer` flag and a `targetApiKeys` list. The marketing endpoints require the flag (or `admin`) and only reach devices registered under the listed keys — the api keys baked into the apps cannot call them, a marketing key can be rotated without an app release, and a key with no targets fails closed.
- **The API**: `POST /marketing/test` (single test push), `POST /marketing/query` (lists the devices a send would reach, filtered by include/exclude lists of cities and regions — lines within a list are alternatives, the lists narrow each other, matching is case-insensitive), and `POST /marketing/push` (sends to the device list a query returned). The send takes device ids rather than a location so the caller blasts exactly the audience it reviewed, and so a stale server fails loudly (unknown route) instead of resolving the same body to a different audience.

Operational notes: the key doc for the tool needs `{ marketer: true, targetApiKeys: ["<app api key>"] }` in `db_api_keys` (no `adminsdk` needed — delivery credentials resolve from each device's own key), and the marketing router parses its own bodies with a 10mb limit ahead of the app-wide 1mb parser.

Tested against a local CouchDB with devices registered through the real `/v2/device` endpoint: include/exclude query counts, tenant scoping (devices under a second app key never matched), the auth matrix (app key 403, unknown key 401, target-less marketer key 400), and queue publishes for exactly the queried device list. `locationFilter` has a mocha suite covering the filter and skip-reason logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New privileged endpoints can queue large marketing audiences if a marketer key is compromised, though scoping to targetApiKeys, confirmation on push, and auth-before-body parsing reduce exposure. Couch view rollout and high-volume query/push paths add operational load but reuse the existing queue and publish pipeline.
> 
> **Overview**
> Adds a **`/marketing`** Express router (mounted before the global JSON parser with a **64mb** body limit) with **`POST /marketing/test`**, **`query`**, and **`push`**. Access requires an **`x-api-key`** with **`marketer`** or **`admin`**, and sends only reach devices whose **`apiKey`** is in that key’s **`targetApiKeys`** list (empty targets return **400**).
> 
> **Query** streams the new Couch **`apiKeyLocation`** view per target key, applies city/region include/exclude filters, and caps results at **2M** devices. **Push** takes an explicit **`deviceIds`** list (from query), requires **`confirmed`**, re-loads devices in batches, then queues marketing messages via the existing **`makePushSender`** path with streaming progress text.
> 
> API key docs gain optional **`marketer`** and **`targetApiKeys`** fields. Couch adds batched **`streamDeviceBatchesByIds`** and **`streamDeviceSummariesByApiKeyLocation`** helpers.
> 
> **Publish daemon** now uses **`isUnregisteredToken`** for Firebase’s current not-registered errors (clears **`deviceToken`**), and fixes Pino logging argument order on send failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59be39d0430ab2f87c5ddd8baaed89b40858878b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->